### PR TITLE
改进包文件获取方式修复潜在问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,19 @@
 import { getDirname, path, fs } from "@vuepress/utils";
 import { defaultTheme } from "@vuepress/theme-default";
 import genSider from "./helper/gen-side/index.js";
-
+import { fileURLToPath } from 'url';
 
 // 创建一个基于默认主题的page文件 并作出修改 是为在右侧放入页面内部导航部分
 const __dirname = getDirname(import.meta.url);
 const newPageFile = path.resolve(__dirname, "./components/Page.vue");
-const pageFile = path.resolve('node_modules/@vuepress/theme-default/lib/client/components/Page.vue');
+const pageFile = fileURLToPath(import.meta.resolve('@vuepress/theme-default/lib/client/components/Page.vue'));
 let pageFileContent = fs.readFileSync(pageFile, "utf8");
 pageFileContent = pageFileContent.replace(`<script setup lang="ts">`, `<script setup lang="ts">\nimport AnchorRight from './anchor-right/index.vue'`);
 pageFileContent = pageFileContent.replace(`<div class="theme-default-content">`, `<div class="theme-default-content">\n<anchor-right/>`);
 fs.writeFileSync(newPageFile, pageFileContent);
 
 const newSidebarItemFile = path.resolve(__dirname, "./components/SidebarItem.vue");
-const sidebarItemFile = "node_modules/@vuepress/theme-default/lib/client/components/SidebarItem.vue";
+const sidebarItemFile = fileURLToPath(import.meta.resolve("@vuepress/theme-default/lib/client/components/SidebarItem.vue"));
 let sidebarItemFileContent = fs.readFileSync(sidebarItemFile, "utf8");
 sidebarItemFileContent = sidebarItemFileContent.replace(`'../../shared/index.js'`, `'@vuepress/theme-default/lib/shared/index.js'`);
 sidebarItemFileContent = sidebarItemFileContent.replace(`'../utils/index.js'`, `'@vuepress/theme-default/lib/client/utils/index.js'`);


### PR DESCRIPTION
相关issuse：https://github.com/dingshaohua-cn/vuepress-theme-sidebar/issues/4

可能导致的问题：
```
PS P:\StellarRealm\website\project\wiki> yarn dev
yarn run v1.22.21
$ vuepress dev wiki
Error: ENOENT: no such file or directory, open 'P:\StellarRealm\website\project\wiki\node_modules\@vuepress\theme-default\lib\client\components\Page.vue'
    at Object.readFileSync (node:fs:453:20)
    at file:///P:/StellarRealm/website/node_modules/vuepress-theme-sidebar/index.js:10:26
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadUserConfig (file:///P:/StellarRealm/website/node_modules/@vuepress/cli/dist/index.js:77:18)
    at async CAC.dev (file:///P:/StellarRealm/website/node_modules/@vuepress/cli/dist/index.js:465:52)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

错误路径：`P:\StellarRealm\website\project\wiki\node_modules\@vuepress\theme-default\lib\client\components\Page.vue`
正确路径：`P:\StellarRealm\website\node_modules\@vuepress\theme-default\lib\client\components\Page.vue`